### PR TITLE
Improve fault tolerance in unstable connection to target machine plarform

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -217,7 +217,7 @@ def load(app):
             'max_instances': 3 #Improve fault tolerance
         }
         scheduler=BackgroundScheduler(job_defaults=job_defaults)
-        scheduler.init_app(app)
+        scheduler = APScheduler(scheduler,app)
         scheduler.start()
         scheduler.add_job(id='whale-auto-clean', func=auto_clean_container, trigger="interval", seconds=10)
         print("[CTFd Whale]Started successfully")


### PR DESCRIPTION
由于我的平台机和靶机平台机之间的连接不稳定，导致长时间运行后APScheduler运行产生异常，卡死的job延续了延长时间，和下一个job产生冲突，max_instances达到上限，大量job运行后，APSchedule完全失去正常运行能力。经过十几天的DEBUG，作如下调整，成功解决问题